### PR TITLE
Bugfix for generic_visit

### DIFF
--- a/pycparserext/c_generator.py
+++ b/pycparserext/c_generator.py
@@ -28,7 +28,7 @@ class CGenerator(object):
         if node is None:
             return ''
         else:
-            return ''.join(self.visit(c) for c in node.children())
+            return ''.join(self.visit(c[1]) for c in node.children())
 
     def visit_Constant(self, n):
         return n.value


### PR DESCRIPTION
Basically, I was using pycparserext, trying to call the visit function to generate code.  I wrote a small C program to experiment with, and found that it broke our code generation (we are basically parsing the code, making small changes to the ast, and regenerating the code from the ast).  The program that caused the trouble is https://github.com/dgoldstein0/pycmutate/blob/master/testcode/unary_ops.c.

one-line change to fix the bug :).  Thought you might want to apply the fix to the main branch of the codebase.
