### PR TITLE
Support For GNU statement expressions. 

### DIFF
--- a/pycparserext/ext_c_parser.py
+++ b/pycparserext/ext_c_parser.py
@@ -439,6 +439,26 @@ class GnuCParser(_AsmAndAttributesMixin, CParserBase):
         p[0] = c_ast.FuncCall(c_ast.ID(p[1], self._coord(p.lineno(1))),
                 TypeList([p[3], p[5]], self._coord(p.lineno(2))))
 
+    def p_gnu_statement_expression(self, p):
+        """ gnu_statement_expression : LPAREN compound_statement RPAREN
+        """
+        p[0] = p[2]
+
+    def p_gnu_primary_expression_6(self, p):
+        """ primary_expression : gnu_statement_expression """
+        p[0] = p[1]
+
+    def p_statement(self, p):
+        """ statement   : labeled_statement
+                        | expression_statement
+                        | compound_statement
+                        | selection_statement
+                        | iteration_statement
+                        | jump_statement
+                        | gnu_statement_expression
+        """
+        p[0] = p[1]
+
     def p_attribute_const(self, p):
         """ attribute : __CONST
         """

--- a/test/test_pycparserext.py
+++ b/test/test_pycparserext.py
@@ -141,6 +141,54 @@ def test_array_ptr_decl_attribute():
     from pycparserext.ext_c_generator import GnuCGenerator
     print(GnuCGenerator().visit(ast))
 
+def test_func_ret_ptr_decl_attribute():
+    src = """
+    extern void* memcpy(const void* src, const void *dst, int len) __attribute__((unused));
+    """
+    from pycparserext.ext_c_parser import GnuCParser
+    p = GnuCParser()
+    ast = p.parse(src)
+    ast.show()
+
+def test_array_ptr_decl_attribute():
+    src = """
+    int* __attribute__((weak)) array[256];
+    """
+
+    from pycparserext.ext_c_parser import GnuCParser
+    p = GnuCParser()
+    ast = p.parse(src)
+    ast.show()
+
+def test_gnu_statement_expression():
+    src = """
+      int func(int a) {
+        return (int)({; ; *(int*)&a;});
+     }
+    """
+    from pycparserext.ext_c_parser import GnuCParser
+    p = GnuCParser()
+    ast = p.parse(src)
+    ast.show()
+
+def test_empty_gnu_statement_expression():
+    # Incase, ASSERTS turn out to be empty statements
+    src = """
+      int func(int a) {
+              ({
+                    ; ;
+                         });
+                }
+    """
+
+    from pycparserext.ext_c_parser import GnuCParser
+    p = GnuCParser()
+    ast = p.parse(src)
+    ast.show()
+
+    from pycparserext.ext_c_generator import GnuCGenerator
+    print(GnuCGenerator().visit(ast))
+
 if __name__ == "__main__":
     import sys
     if len(sys.argv) > 1:

--- a/test/test_pycparserext.py
+++ b/test/test_pycparserext.py
@@ -189,6 +189,22 @@ def test_empty_gnu_statement_expression():
     from pycparserext.ext_c_generator import GnuCGenerator
     print(GnuCGenerator().visit(ast))
 
+def test_lvalue_gnu_statement_expression():
+    src = """
+      int func(int a) {
+        int ret=(int)({; ; *(int*)&a;});
+        return ret;
+     }
+    """
+
+    from pycparserext.ext_c_parser import GnuCParser
+    p = GnuCParser()
+    ast = p.parse(src)
+    ast.show()
+
+    from pycparserext.ext_c_generator import GnuCGenerator
+    print(GnuCGenerator().visit(ast))
+
 if __name__ == "__main__":
     import sys
     if len(sys.argv) > 1:


### PR DESCRIPTION
GnuCParser extension for supporting GNU statement expressions. More on Gnu statement expressions here, https://gcc.gnu.org/onlinedocs/gcc/Statement-Exprs.html
Statement expressions are the only way a macro can return l-value and hence very powerful. 