### PR TITLE
Fixed ambiguity in if-expr-asm-semi-else-asm-semi

### DIFF
--- a/pycparserext/ext_c_parser.py
+++ b/pycparserext/ext_c_parser.py
@@ -300,30 +300,30 @@ class _AsmMixin(object):
         p[0] = None
 
     def p_asm_opt_2(self, p):
-        """ asm_opt : asm
+        """ asm_opt : asm_no_semi
         """
         p[0] = p[1]
 
     def p_asm_1(self, p):
-        """ asm : asm_keyword LPAREN asm_argument_expression_list RPAREN
+        """ asm_no_semi : asm_keyword LPAREN asm_argument_expression_list RPAREN
         """
         p[0] = Asm(p[1], p[3], None, None, None, coord=self._coord(p.lineno(1)))
 
     def p_asm_2(self, p):
-        """ asm : asm_keyword LPAREN asm_argument_expression_list COLON \
+        """ asm_no_semi : asm_keyword LPAREN asm_argument_expression_list COLON \
                 asm_argument_expression_list RPAREN
         """
         p[0] = Asm(p[1], p[3], p[5], None, None, coord=self._coord(p.lineno(1)))
 
     def p_asm_3(self, p):
-        """ asm : asm_keyword LPAREN asm_argument_expression_list COLON \
+        """ asm_no_semi : asm_keyword LPAREN asm_argument_expression_list COLON \
                 asm_argument_expression_list COLON asm_argument_expression_list \
                 RPAREN
         """
         p[0] = Asm(p[1], p[3], p[5], p[7], None, coord=self._coord(p.lineno(1)))
 
     def p_asm_4(self, p):
-        """ asm : asm_keyword LPAREN asm_argument_expression_list COLON \
+        """ asm_no_semi : asm_keyword LPAREN asm_argument_expression_list COLON \
                 asm_argument_expression_list COLON asm_argument_expression_list \
                 COLON asm_argument_expression_list RPAREN
         """
@@ -351,14 +351,15 @@ class _AsmMixin(object):
         p[0] = p[1]
 
     def p_statement_gnu(self, p):
-        """ statement   : asm
+        """ statement   : asm_no_semi
+                        | asm_no_semi SEMI
         """
         p[0] = p[1]
 
-    def p_asm_with_semi(self, p):
-        """ asm : asm SEMI
-        """
-        p[0] = p[1]
+#    def p_asm_with_semi(self, p):
+#        """ asm : asm SEMI
+#        """
+#        p[0] = p[1]
 
 
 class _AsmAndAttributesMixin(_AsmMixin, _AttributesMixin):

--- a/pycparserext/ext_c_parser.py
+++ b/pycparserext/ext_c_parser.py
@@ -355,6 +355,11 @@ class _AsmMixin(object):
         """
         p[0] = p[1]
 
+    def p_asm_with_semi(self, p):
+        """ asm : asm SEMI
+        """
+        p[0] = p[1]
+
 
 class _AsmAndAttributesMixin(_AsmMixin, _AttributesMixin):
     # {{{ /!\ names must match C parser to override

--- a/pycparserext/ext_c_parser.py
+++ b/pycparserext/ext_c_parser.py
@@ -470,6 +470,10 @@ class GnuCParser(_AsmAndAttributesMixin, CParserBase):
         """
         p[0] = c_ast.ID(name="__const", coord=self._coord(p.lineno(1)))
 
+    def p_struct_declaration_list_1(self, p):
+        """ struct_declaration_list : empty """
+        p[0] = None
+
 # }}}
 
 

--- a/test/test_pycparserext.py
+++ b/test/test_pycparserext.py
@@ -127,6 +127,17 @@ def test_funky_header_code_4():
     from pycparserext.ext_c_generator import GnuCGenerator
     print(GnuCGenerator().visit(ast))
 
+def test_funky_header_code_5():
+    src=""" void  do_foo(void) __asm(__STRING(do_foo));"""
+
+    from pycparserext.ext_c_parser import GnuCParser
+    p = GnuCParser()
+    ast = p.parse(src)
+    ast.show()
+
+    from pycparserext.ext_c_generator import GnuCGenerator
+    print(GnuCGenerator().visit(ast))
+
 @pytest.mark.parametrize("typename", ["int", "uint"])
 def test_opencl(typename):
     from pycparserext.ext_c_parser import OpenCLCParser
@@ -210,6 +221,9 @@ def test_func_ret_ptr_decl_attribute():
     p = GnuCParser()
     ast = p.parse(src)
     ast.show()
+
+    from pycparserext.ext_c_generator import GnuCGenerator
+    print(GnuCGenerator().visit(ast))
 
 def test_array_ptr_decl_attribute():
     src = """

--- a/test/test_pycparserext.py
+++ b/test/test_pycparserext.py
@@ -280,6 +280,20 @@ def test_lvalue_gnu_statement_expression():
     from pycparserext.ext_c_generator import GnuCGenerator
     print(GnuCGenerator().visit(ast))
 
+def test_empty_struct_declaration():
+    src = """
+        typedef struct Foo {
+        } Foo_t;
+    """
+
+    from pycparserext.ext_c_parser import GnuCParser
+    p = GnuCParser()
+    ast = p.parse(src)
+    ast.show()
+
+    from pycparserext.ext_c_generator import GnuCGenerator
+    print(GnuCGenerator().visit(ast))
+
 if __name__ == "__main__":
     import sys
     if len(sys.argv) > 1:

--- a/test/test_pycparserext.py
+++ b/test/test_pycparserext.py
@@ -65,6 +65,67 @@ def test_funky_header_code():
     from pycparserext.ext_c_generator import GnuCGenerator
     print(GnuCGenerator().visit(ast))
 
+def test_funky_header_code_2():
+    src = """
+        extern __inline int __attribute__ ((__nothrow__)) __signbitf (float __x)
+         {
+           int __m;
+           if (__x == 0)
+              __asm ("pmovmskb %1, %0" : "=r" (__m) : "x" (__x));
+           else
+              __asm ("pmovmskb %1, %0" : "=r" (__m) : "x" (__x));
+           return __m & 0x8;
+         }
+        """
+
+    from pycparserext.ext_c_parser import GnuCParser
+    p = GnuCParser()
+    ast = p.parse(src)
+    ast.show()
+
+    from pycparserext.ext_c_generator import GnuCGenerator
+    print(GnuCGenerator().visit(ast))
+
+def test_funky_header_code_3():
+    src = """
+        extern __inline int __attribute__ ((__nothrow__)) __signbitf (float __x)
+         {
+           int __m;
+           if (__x == 0)
+              __asm ("pmovmskb %1, %0" : "=r" (__m) : "x" (__x));
+           return __m & 0x8;
+         }
+        """
+
+    from pycparserext.ext_c_parser import GnuCParser
+    p = GnuCParser()
+    ast = p.parse(src)
+    ast.show()
+
+    from pycparserext.ext_c_generator import GnuCGenerator
+    print(GnuCGenerator().visit(ast))
+
+def test_funky_header_code_4():
+    src = """
+        extern __inline int __attribute__ ((__nothrow__)) __signbitf (float __x)
+         {
+           int __m;
+           if (__x == 0) {
+              __asm ("pmovmskb %1, %0" : "=r" (__m) : "x" (__x));
+           } else {
+              __asm ("pmovmskb %1, %0" : "=r" (__m) : "x" (__x));
+           }
+           return __m & 0x8;
+         }
+        """
+
+    from pycparserext.ext_c_parser import GnuCParser
+    p = GnuCParser()
+    ast = p.parse(src)
+    ast.show()
+
+    from pycparserext.ext_c_generator import GnuCGenerator
+    print(GnuCGenerator().visit(ast))
 
 @pytest.mark.parametrize("typename", ["int", "uint"])
 def test_opencl(typename):


### PR DESCRIPTION
Statements of the below form resulted in shift-reduce conflict since asm was directly reduced to a statement production.
>
if (expr)
   asm();
else
   asm();
>
The above if-else clause is ambiguous when the state of the parser is
IF LPAREN expression RPAREN asm --> LookAheadToken(';') since asm can be reduced to a statement the parser performs a right most derivation of "asm" as statement with the next look_ahead token as semi-colon (';) matching the production IF LPAREN expression RPAREN statement as a selection statement. In the new state ';' (as look ahead token) is an invalid/unexpected token as selection statements can only be of the form
selection_statement: IF LPAREN expression RPAREN statement 
selection_statement: IF LPAREN expression RPAREN statement else statement
The solution is to reduce asm followed by semi-colon as a statement expression so as to remove the ambiguity when the next token is ELSE or something else.  

I have added the concerned test-cases in the test file and it seems to be running fine with the new grammar  changes. 