### PR TITLE
Fix name of overridden method.

### DIFF
--- a/pycparserext/ext_c_parser.py
+++ b/pycparserext/ext_c_parser.py
@@ -353,7 +353,7 @@ class _AsmMixin(object):
 class _AsmAndAttributesMixin(_AsmMixin, _AttributesMixin):
     # {{{ /!\ names must match C parser to override
 
-    def p_direct_declarator_5(self, p):
+    def p_direct_declarator_6(self, p):
         """ direct_declarator   : direct_declarator LPAREN parameter_type_list \
                                         RPAREN asm_opt attributes_opt
                                 | direct_declarator LPAREN identifier_list_opt \


### PR DESCRIPTION
In pycparser's commit 4a6afa0587bfb340dad5838f847e71704ea48ea7, the
method p_direct_declarator_5 was renamed to p_direct_declarator_6.
Because pycparserext didn't track this rename, sometimes the method from
the base class, which was supposed to be replaced, was called.  Also,
this broke the rarely-used `int A[*]` VLA syntax, because the method for
that from the base class was replaced instead.