### PR TITLE
Enable pragma support

### DIFF
--- a/pycparserext/ext_c_parser.py
+++ b/pycparserext/ext_c_parser.py
@@ -456,6 +456,7 @@ class GnuCParser(_AsmAndAttributesMixin, CParserBase):
                         | selection_statement
                         | iteration_statement
                         | jump_statement
+                        | pppragma_directive
                         | gnu_statement_expression
         """
         p[0] = p[1]


### PR DESCRIPTION
Pragma directives inside function declarations are now correctly parsed. They would previously raise a ParseError.