### PR TITLE
Fix coord line numbers for Asm nodes.

### DIFF
--- a/pycparserext/ext_c_parser.py
+++ b/pycparserext/ext_c_parser.py
@@ -297,27 +297,27 @@ class _AsmMixin(object):
     def p_asm_1(self, p):
         """ asm_no_semi : asm_keyword LPAREN asm_argument_expression_list RPAREN
         """
-        p[0] = Asm(p[1], p[3], None, None, None, coord=self._coord(p.lineno(1)))
+        p[0] = Asm(p[1], p[3], None, None, None, coord=self._coord(p.lineno(2)))
 
     def p_asm_2(self, p):
         """ asm_no_semi : asm_keyword LPAREN asm_argument_expression_list COLON \
                 asm_argument_expression_list RPAREN
         """
-        p[0] = Asm(p[1], p[3], p[5], None, None, coord=self._coord(p.lineno(1)))
+        p[0] = Asm(p[1], p[3], p[5], None, None, coord=self._coord(p.lineno(2)))
 
     def p_asm_3(self, p):
         """ asm_no_semi : asm_keyword LPAREN asm_argument_expression_list COLON \
                 asm_argument_expression_list COLON asm_argument_expression_list \
                 RPAREN
         """
-        p[0] = Asm(p[1], p[3], p[5], p[7], None, coord=self._coord(p.lineno(1)))
+        p[0] = Asm(p[1], p[3], p[5], p[7], None, coord=self._coord(p.lineno(2)))
 
     def p_asm_4(self, p):
         """ asm_no_semi : asm_keyword LPAREN asm_argument_expression_list COLON \
                 asm_argument_expression_list COLON asm_argument_expression_list \
                 COLON asm_argument_expression_list RPAREN
         """
-        p[0] = Asm(p[1], p[3], p[5], p[7], p[9], coord=self._coord(p.lineno(1)))
+        p[0] = Asm(p[1], p[3], p[5], p[7], p[9], coord=self._coord(p.lineno(2)))
 
     def p_asm_keyword(self, p):
         """ asm_keyword : __ASM__ asm_volatile


### PR DESCRIPTION
This fixes the issue #40. Please note that that fixes the issue only halfway. Coord.column will be always set to None for Asm nodes (although it could be inferred from the yacc context)...