### PR TITLE
Add emit_declname parameter to _generate_type to match pycparser

### DIFF
--- a/pycparserext/ext_c_generator.py
+++ b/pycparserext/ext_c_generator.py
@@ -39,7 +39,7 @@ class AsmAndAttributesMixin(object):
                 " : ".join(
                     self.visit(c) for c in components))
 
-    def _generate_type(self, n, modifiers=[]):
+    def _generate_type(self, n, modifiers=[], emit_declname=True):
         """ Recursive generation from a type node. n is the type node.
             modifiers collects the PtrDecl, ArrayDecl and FuncDecl modifiers
             encountered on the way down to a TypeDecl, to allow proper
@@ -54,7 +54,7 @@ class AsmAndAttributesMixin(object):
                 s += ' '.join(n.quals) + ' '
             s += self.visit(n.type)
 
-            nstr = n.declname if n.declname else ''
+            nstr = n.declname if n.declname and emit_declname else ''
             # Resolve modifiers.
             # Wrap in parens to distinguish pointer to array and pointer to
             # function syntax.
@@ -110,13 +110,14 @@ class AsmAndAttributesMixin(object):
             return self._generate_decl(n.type)
 
         elif typ == c_ast.Typename:
-            return self._generate_type(n.type)
+            return self._generate_type(n.type, emit_declname=emit_declname)
 
         elif typ == c_ast.IdentifierType:
             return ' '.join(n.names) + ' '
 
         elif typ in (c_ast.ArrayDecl, c_ast.PtrDecl, c_ast.FuncDecl, FuncDeclExt):
-            return self._generate_type(n.type, modifiers + [n])
+            return self._generate_type(
+                    n.type, modifiers + [n], emit_declname=emit_declname)
 
         else:
             return self.visit(n)

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(name="pycparserext",
       python_requires="~=3.6",
       install_requires=[
           "ply>=3.4",
-          "pycparser>=2.18,<2.20",
+          "pycparser>=2.18,<=2.20",
           ],
 
       author="Andreas Kloeckner",

--- a/test/test_pycparserext.py
+++ b/test/test_pycparserext.py
@@ -595,6 +595,21 @@ def test_typeof_reproduction():
                visit_num[2] == visit_num[3], assert_msg
 
 
+def test_typedef():
+    from pycparser import c_ast
+    from pycparserext.ext_c_parser import GnuCParser
+    from pycparserext.ext_c_generator import GnuCGenerator
+
+    p = GnuCParser()
+
+    first_ast = p.parse('typedef int foo;').ext[0]
+    assert isinstance(first_ast, c_ast.Typedef)
+
+    gen = GnuCGenerator().visit(first_ast.type)
+
+    assert gen == 'int'
+
+
 if __name__ == "__main__":
     import sys
     if len(sys.argv) > 1:


### PR DESCRIPTION
As of https://github.com/eliben/pycparser/pull/315, _generate_type()
makes emitting the declname configurable. Do the same in ext_c_generator
to avoid a TypeError.