### PR TITLE
Add support for attribute in between pointer and declaration name

### DIFF
--- a/pycparserext/ext_c_parser.py
+++ b/pycparserext/ext_c_parser.py
@@ -404,22 +404,31 @@ class _AsmAndAttributesMixin(_AsmMixin, _AttributesMixin):
                                 attributes_opt
                             | pointer attributes_opt direct_xxx_declarator \
                                 asm_label_opt
+                            | attributes_opt pointer direct_xxx_declarator \
+                                asm_label_opt
         """
         if hasattr(p[4], "exprs"):
             attr_decl = p[4]
             asm_label = p[3]
             decl = p[2]
-        else:
+            ptr = p[1]
+        elif hasattr(p[2], "exprs"):
             attr_decl = p[2]
             asm_label = p[4]
             decl = p[3]
+            ptr = p[1]
+        else:
+            attr_decl = p[1]
+            asm_label = p[4]
+            decl = p[3]
+            ptr = p[2]
 
         if asm_label or attr_decl.exprs:
             if isinstance(decl, (c_ast.ArrayDecl, c_ast.FuncDecl)):
-                decl_ext = to_decl_ext(decl.type)
+                decl = to_decl_ext(decl.type)
 
             elif isinstance(decl, c_ast.TypeDecl):
-                decl_ext = to_decl_ext(decl)
+                decl = to_decl_ext(decl)
 
             else:
                 raise NotImplementedError(
@@ -427,14 +436,12 @@ class _AsmAndAttributesMixin(_AsmMixin, _AttributesMixin):
                     % type(p[1]))
 
             if asm_label:
-                decl_ext.asm = asm_label
+                decl.asm = asm_label
 
             if attr_decl.exprs:
-                decl_ext.attributes = attr_decl
+                decl.attributes = attr_decl
 
-            p[1] = decl_ext
-
-        p[0] = self._type_modify_decl(decl, p[1])
+        p[0] = self._type_modify_decl(decl, ptr)
 
     @parameterized(('id', 'ID'), ('typeid', 'TYPEID'), ('typeid_noparen', 'TYPEID'))
     def p_direct_xxx_declarator_6(self, p):

--- a/test/test_pycparserext.py
+++ b/test/test_pycparserext.py
@@ -318,7 +318,8 @@ def test_func_attribute_before_direct_declarator():
     src_regen = GnuCGenerator().visit(ast)
     print(src_regen)
 
-    # _round_trip_matches trips at comparing the function specifiers here, as they are lists
+    # _round_trip_matches trips at comparing the function
+    #   specifiers here, as they are lists
     # (how was this supposed to work, again?)
     # assert _round_trip_matches(src)
 

--- a/test/test_pycparserext.py
+++ b/test/test_pycparserext.py
@@ -300,6 +300,23 @@ def test_array_ptr_decl_attribute():
     print(GnuCGenerator().visit(ast))
 
 
+def test_func_attribute_before_direct_declarator():
+    src = """
+    int __attribute__((stdcall)) function(void);
+    int (*fptr1)(int, int);
+    int (* __attribute__((stdcall)) fptr2)(int, int);
+    int (__attribute__((stdcall)) *fptr3)(int, int);
+    """
+    from pycparserext.ext_c_parser import GnuCParser
+    p = GnuCParser()
+    ast = p.parse(src)
+    ast.show()
+
+    from pycparserext.ext_c_generator import GnuCGenerator
+    print(GnuCGenerator().visit(ast))
+
+
+
 def test_gnu_statement_expression():
     src = """
       int func(int a) {

--- a/test/test_pycparserext.py
+++ b/test/test_pycparserext.py
@@ -302,7 +302,9 @@ def test_array_ptr_decl_attribute():
 
 def test_func_attribute_before_direct_declarator():
     src = """
-    int __attribute__((stdcall)) function(void);
+    __attribute__((stdcall)) int func1(void);
+    int __attribute__((stdcall)) func2(void);
+    int func3(void) __attribute__((stdcall));
     int (*fptr1)(int, int);
     int (* __attribute__((stdcall)) fptr2)(int, int);
     int (__attribute__((stdcall)) *fptr3)(int, int);
@@ -313,8 +315,20 @@ def test_func_attribute_before_direct_declarator():
     ast.show()
 
     from pycparserext.ext_c_generator import GnuCGenerator
-    print(GnuCGenerator().visit(ast))
+    src_regen = GnuCGenerator().visit(ast)
+    print(src_regen)
 
+    # _round_trip_matches trips at comparing the function specifiers here, as they are lists
+    # (how was this supposed to work, again?)
+    # assert _round_trip_matches(src)
+
+    assert src_regen == """ __attribute__((stdcall)) int func1(void);
+ __attribute__((stdcall)) int func2(void);
+int func3(void) __attribute__((stdcall));
+int (*fptr1)(int, int);
+int (*fptr2)(int, int) __attribute__((stdcall));
+int (*fptr3)(int, int) __attribute__((stdcall));
+"""
 
 
 def test_gnu_statement_expression():


### PR DESCRIPTION
- Add support for declarations like `int (* __attribute__((stdcall)) fptr)(void)`
- Add a test case for the aforementioned case
- Fix regression introduced in #54, which caused function pointer information to be discarded in case any attributes or asm labels were present