### PR TITLE
Improve support for __extension__ keyword

### DIFF
--- a/pycparserext/ext_c_parser.py
+++ b/pycparserext/ext_c_parser.py
@@ -546,6 +546,14 @@ class GnuCParser(_AsmAndAttributesMixin, CParserBase):
         """
         p[0] = p[1]
 
+    def p_gnu_primary_expression_7(self, p):
+        """ primary_expression : __EXTENSION__ primary_expression """
+        p[0] = p[2]
+
+    def p_gnu_assignment_expression_2(self, p):
+        """ assignment_expression : __EXTENSION__ assignment_expression """
+        p[0] = p[2]
+
     def p_attribute_const(self, p):
         """ attribute : __CONST
         """

--- a/test/test_pycparserext.py
+++ b/test/test_pycparserext.py
@@ -348,6 +348,19 @@ def test_lvalue_gnu_statement_expression():
     print(GnuCGenerator().visit(ast))
 
 
+def test_gnu_extension_expression():
+    src = """
+      int func(int a) {
+        int i = (4,__extension__ 2);
+        char * name = __extension__ __PRETTY_FUNCTION__;
+        i = __extension__ i++;
+        i = __extension__((__extension__ i)++ + (--(__extension__ i)));
+        return __extension__(int)__extension__({; ; i;});
+     }
+    """
+    assert _round_trip_matches(src)
+
+
 def test_empty_struct_declaration():
     src = """
         typedef struct Foo {


### PR DESCRIPTION
This keyword is allowed to appear before expressions in GNU C and serves as a hint to the compiler to not issue a warning in case a GNU C specific extension is used, cf.:
https://gcc.gnu.org/onlinedocs/gcc/Alternate-Keywords.html

The two additional parser rules in this commit will allow to parse that keyword correctly when it appears before an expression.

For now, the keyword is not reproduced when code is generated from the AST, but this should not be a problem as it is just controlling compiler warnings and does not affect semantics (as outlined above).

---

this PR will likely lead to an easy-to-solve merge conflict once PR #71 is merged. I would simply update this PR by rebasing in that case. Getting #71 merged first is my preferred order. I considered bundling both changes into one PR but they are really orthogonal and this did not feel right.