### PR TITLE
added __typeof expression type_specifier, it is another alias for __typeof__; also test added too

### DIFF
--- a/pycparserext/ext_c_lexer.py
+++ b/pycparserext/ext_c_lexer.py
@@ -65,7 +65,7 @@ _COMMON_KEYWORDS = [
     '__asm__', '__asm', 'asm']
 
 _GNU_KEYWORDS = [
-    '__typeof__', 'typeof',
+    '__typeof__', 'typeof', '__typeof',
     '__real__', '__imag__',
     '__builtin_types_compatible_p',
     '__const',

--- a/pycparserext/ext_c_parser.py
+++ b/pycparserext/ext_c_parser.py
@@ -512,6 +512,7 @@ class GnuCParser(_AsmAndAttributesMixin, CParserBase):
     def p_type_specifier_gnu_typeof_expr(self, p):
         """ type_specifier  : __TYPEOF__ LPAREN expression RPAREN
                             | TYPEOF LPAREN expression RPAREN
+                            | __TYPEOF LPAREN expression RPAREN
         """
         if isinstance(p[3], c_ast.TypeDecl):
             pass
@@ -521,6 +522,7 @@ class GnuCParser(_AsmAndAttributesMixin, CParserBase):
     def p_type_specifier_gnu_typeof_decl(self, p):
         """ type_specifier  : __TYPEOF__ LPAREN parameter_declaration RPAREN
                             | TYPEOF LPAREN parameter_declaration RPAREN
+                            | __TYPEOF LPAREN parameter_declaration RPAREN
         """
         p[0] = TypeOfDeclaration(p[1], p[3])
 

--- a/test/test_pycparserext.py
+++ b/test/test_pycparserext.py
@@ -509,7 +509,7 @@ def test_node_visitor():
         "Asm": [0, 1],
         # PreprocessorLine is OpenCL, not GNU
         "PreprocessorLine": [0, 0],
-        "TypeOfDeclaration": [0, 4],
+        "TypeOfDeclaration": [0, 6],
         "TypeOfExpression": [0, 1],
         "FuncDeclExt": [0, 1],
     }
@@ -548,6 +548,7 @@ def test_node_visitor():
         __typeof__(a) _a = __builtin_types_compatible_p(long char, short int);
         __typeof__ (__typeof__ (char *)[4]) y;
         typeof (typeof (char *)[4]) z;
+        __typeof (__typeof (char *)[4]) g;
         asm("rdtsc" : "=A" (val));
         __attribute__((unused)) static int c;
     }
@@ -569,9 +570,11 @@ def test_typeof_reproduction():
     int func(int a, int b) {
         __typeof__(a) _a = a;
         typeof(b) _b = b;
+        __typeof(c) _c = c;
 
         __typeof__ (__typeof__ (char *)[4]) y;
         typeof (typeof (char *)[4]) z;
+        __typeof (__typeof (char *)[4]) g;
     }
     """
     assert _round_trip_matches(src)
@@ -581,10 +584,12 @@ def test_typeof_reproduction():
 
     # key is type of visit, value is
     # [actual # __typeof__, expected # __typeof__,
-    #   actual # typeof, expected # typeof]
+    #   actual # typeof, expected # typeof,
+    #   actual # __typeof, expected # __typeof
+    # ]
     visits = {
-        "TypeOfDeclaration": [0, 2, 0, 2],
-        "TypeOfExpression": [0, 1, 0, 1],
+        "TypeOfDeclaration": [0, 2, 0, 4],
+        "TypeOfExpression": [0, 1, 0, 2],
     }
 
     class TestVisitor(NodeVisitor):


### PR DESCRIPTION
fixes #79 

c code i was trying to parse contains __typeof keyword, which is an alias of __typeof__ but was failed to parse, because was not defined