### PR TITLE
feat: Add regression test for __alignof__ in attribute

### DIFF
--- a/test/test_pycparserext.py
+++ b/test/test_pycparserext.py
@@ -576,6 +576,11 @@ def test_alignof():
     assert _round_trip_matches(src)
 
 
+def test_alignof_in_attribute():
+    src = "long long z __attribute__((aligned(__alignof__(long long))));"
+    assert _round_trip_matches(src)
+
+
 def test_typeof_reproduction():
     src = """
     int func(int a, int b) {


### PR DESCRIPTION
Adds a regression test to ensure that `__alignof__` can be used within an `__attribute__((aligned(...)))` specifier. This test verifies that the bug reported in issues #65 and #73 does not reappear in the future.

The bug itself appears to have been fixed in a previous version of `pycparserext` or one of its dependencies, as the test passes without any code changes. Just to make sure that #65 and #73 could be closed

Closes #65.
Closes #73.