### PR TITLE
Fix #33: Support asm labels on register variables

### DIFF
--- a/pycparserext/ext_c_parser.py
+++ b/pycparserext/ext_c_parser.py
@@ -187,7 +187,7 @@ class RangeExpression(c_ast.Node):
 # These are the same as pycparser's, but it does *not* declare __slots__--
 # so we can poke in attributes at our leisure.
 class TypeDeclExt(c_ast.TypeDecl):
-    __slots__ = ('asm', 'attributes', 'init')
+    __slots__ = ("asm", "attributes", "init")
 
     @staticmethod
     def from_pycparser(td):
@@ -203,7 +203,7 @@ class TypeDeclExt(c_ast.TypeDecl):
 
 
 class ArrayDeclExt(c_ast.ArrayDecl):
-    __slots__ = ('asm', 'attributes', 'init')
+    __slots__ = ("asm", "attributes", "init")
 
     @staticmethod
     def from_pycparser(ad):

--- a/test/test_pycparserext.py
+++ b/test/test_pycparserext.py
@@ -126,8 +126,9 @@ def test_asm_label():
 
 
 def test_register_asm_label():
-    from pycparserext.ext_c_parser import GnuCParser, TypeDeclExt
     from pycparser import c_ast
+
+    from pycparserext.ext_c_parser import GnuCParser, TypeDeclExt
     src = 'register int my_var asm("my_reg");'
     p = GnuCParser()
     ast = p.parse(src)
@@ -135,12 +136,12 @@ def test_register_asm_label():
     assert isinstance(decl, c_ast.Decl)
 
     # The asm attribute should be on the TypeDeclExt, not the Decl
-    assert not hasattr(decl, 'asm')
+    assert not hasattr(decl, "asm")
 
     # The declarator part of the Decl should be a TypeDeclExt
     # with the asm attribute.
     assert isinstance(decl.type, TypeDeclExt)
-    assert hasattr(decl.type, 'asm')
+    assert hasattr(decl.type, "asm")
     assert decl.type.asm is not None
     assert decl.type.asm.template.value == '"my_reg"'
 


### PR DESCRIPTION
Fixes #33  
  
Adds support for parsing GNU C extension syntax:  
```c  
register int my_var asm("my_reg"); 
```