### PR TITLE
Fix #75: Support __attribute__ within struct declarations

### DIFF
--- a/pycparserext/ext_c_generator.py
+++ b/pycparserext/ext_c_generator.py
@@ -127,6 +127,11 @@ class AsmAndAttributesMixin:
         else:
             return self.visit(n)
 
+    def visit_AttributeSpecifier(self, n):
+        return "__attribute__((" + self.visit(n.exprlist) + "))"
+
+
+class GnuCGenerator(AsmAndAttributesMixin, CGeneratorBase):
     def _generate_decl(self, n):
         """ Generation from a Decl node.
         """
@@ -145,11 +150,6 @@ class AsmAndAttributesMixin:
         s += self._generate_type(n.type)
         return s
 
-    def visit_AttributeSpecifier(self, n):
-        return " __attribute__((" + self.visit(n.exprlist) + "))"
-
-
-class GnuCGenerator(AsmAndAttributesMixin, CGeneratorBase):
     def visit_TypeOfDeclaration(self, n):
         return "%s(%s)" % (n.typeof_keyword, self.visit(n.declaration))
 

--- a/test/test_pycparserext.py
+++ b/test/test_pycparserext.py
@@ -755,6 +755,16 @@ def test_packed_anonymous_struct_in_struct_after():
     assert _round_trip_matches(code)
 
 
+def test_attribute_in_struct():
+    # https://github.com/inducer/pycparserext/issues/75
+    src = """
+    typedef struct {
+        __attribute__((__deprecated__)) int test1;
+    } test2;
+    """
+    assert _round_trip_matches(src)
+
+
 if __name__ == "__main__":
     import sys
     if len(sys.argv) > 1:


### PR DESCRIPTION
This commit fixes issue #75 where __attribute__ specifiers within struct declarations were not parsed correctly, leading to a ParseError.

Example code that now parses correctly:
```c
    typedef struct {
        __attribute__((__deprecated__)) int test1;
    } test2;
```

Changes:
- Extended specifier_qualifier_list rule in GnuCParser to handle function_specifier nodes, allowing __attribute__ within structs
- Added _p_specifier_qualifier_list_left_recursion method to correctly handle AttributeSpecifier nodes in the funcspec list
- Modified _generate_decl in GnuCGenerator to handle funcspec list with AttributeSpecifier nodes
- Improved AttributeSpecifier.__eq__ to use structural comparison of AST nodes instead of object identity
- Added round-trip test to verify the fix