### PR TITLE
fix __extension__

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build
+test
 .*.sw[po]
 .sw[po]
 *~

--- a/pycparserext/ext_c_parser.py
+++ b/pycparserext/ext_c_parser.py
@@ -413,8 +413,9 @@ class CParserBase(pycparser.c_parser.CParser):
 _GNU_FUNCTION_SPECS = frozenset({"__INLINE__", "__INLINE"})
 _GNU_TYPE_QUALIFIERS = frozenset({
     "__CONST", "__RESTRICT__", "__RESTRICT",
-    "__EXTENSION__", "__VOLATILE", "__VOLATILE__",
+    "__VOLATILE", "__VOLATILE__",
 })
+_GNU_EXPR_QUALIFIERS = frozenset({"__EXTENSION__"})
 _TYPEOF_TOKENS = frozenset({"__TYPEOF__", "TYPEOF", "__TYPEOF"})
 _ATTRIBUTE_TOKENS = frozenset({"__ATTRIBUTE__", "__ATTRIBUTE"})
 
@@ -444,7 +445,7 @@ class _AsmAndAttributesMixin:
         saw_paren = False
         while self._accept("TIMES"):
             # Skip standard and GNU type qualifiers after '*'
-            while self._peek_type() in (_TYPE_QUALIFIER | _GNU_TYPE_QUALIFIERS):
+            while self._peek_type() in (_TYPE_QUALIFIER | _GNU_TYPE_QUALIFIERS | _GNU_EXPR_QUALIFIERS):
                 self._advance()
             # Skip __attribute__((...)) between '*' and declarator name
             while self._peek_type() in _ATTRIBUTE_TOKENS:
@@ -704,6 +705,7 @@ _GNU_DECL_START = (
     _DECL_START
     | _GNU_FUNCTION_SPECS
     | _GNU_TYPE_QUALIFIERS
+    | _GNU_EXPR_QUALIFIERS
     | _TYPEOF_TOKENS
     | _ATTRIBUTE_TOKENS
 )
@@ -759,6 +761,12 @@ class GnuCParser(_AsmAndAttributesMixin, CParserBase):
                     first_coord = self._tok_coord(tok)
                 spec = self._add_declaration_specifier(
                     spec, self._advance().value, "qual", append=True)
+                continue
+
+            if tok_type in _GNU_EXPR_QUALIFIERS:
+                if first_coord is None:
+                    first_coord = self._tok_coord(tok)
+                self._advance()
                 continue
 
             if tok_type in _STORAGE_CLASS:
@@ -894,6 +902,12 @@ class GnuCParser(_AsmAndAttributesMixin, CParserBase):
                     spec, self._advance().value, "qual", append=True)
                 continue
 
+            if tok_type in _GNU_EXPR_QUALIFIERS:
+                if first_coord is None:
+                    first_coord = self._tok_coord(tok)
+                self._advance()
+                continue
+
             if tok_type in _GNU_FUNCTION_SPECS:
                 if first_coord is None:
                     first_coord = self._tok_coord(tok)
@@ -969,7 +983,7 @@ class GnuCParser(_AsmAndAttributesMixin, CParserBase):
 
     def _parse_type_qualifier_list(self):
         quals = []
-        all_quals = _TYPE_QUALIFIER | _GNU_TYPE_QUALIFIERS
+        all_quals = _TYPE_QUALIFIER | _GNU_TYPE_QUALIFIERS | _GNU_EXPR_QUALIFIERS
         while self._peek_type() in all_quals:
             quals.append(self._advance().value)
         return quals
@@ -977,7 +991,7 @@ class GnuCParser(_AsmAndAttributesMixin, CParserBase):
     def _parse_array_decl_common(self, base_type, coord=None):
         """Override to handle GNU type qualifiers inside array dimensions."""
         from pycparser.c_parser import _TYPE_QUALIFIER
-        all_quals = _TYPE_QUALIFIER | _GNU_TYPE_QUALIFIERS
+        all_quals = _TYPE_QUALIFIER | _GNU_TYPE_QUALIFIERS | _GNU_EXPR_QUALIFIERS
 
         lbrack_tok = self._expect("LBRACKET")
         if coord is None:

--- a/test/test_pycparserext.py
+++ b/test/test_pycparserext.py
@@ -520,6 +520,18 @@ def test_case_ranges():
     assert _round_trip_matches(src)
 
 
+def test_extension():
+    src = """
+    __extension__ typedef unsigned long long uint64_t;
+    """
+
+    from pycparserext import ext_c_generator, ext_c_parser
+    parser = ext_c_parser.GnuCParser()
+    ast = parser.parse(src)
+    gen = ext_c_generator.GnuCGenerator()
+    assert(src.strip().removeprefix('__extension__').strip() == gen.visit(ast).strip())
+
+
 @pytest.mark.parametrize("restrict_kw", ["restrict", "__restrict__", "__restrict"])
 def test_restrict(restrict_kw):
     src = """


### PR DESCRIPTION
Fix for #103.
Solved by removing the `__extension__` keyword when seen in the code.
It works since this keyword is used to flag non ANSI C and most of non ANSI C is not parsed by pycparser.
Note: It could create warnings after during the compilation. 

I made a little test with a `typedef` that is a MWE of a similar use of `__extension__` that can be found in `<string.h>`